### PR TITLE
Add GitHub Actions workflow for httpd build testing.

### DIFF
--- a/.github/workflows/httpd-build.yml
+++ b/.github/workflows/httpd-build.yml
@@ -1,0 +1,59 @@
+name: Apache httpd Test Suite CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Test against httpd ${{ matrix.branch }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [trunk, 2.4.x]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Checkout httpd ${{ matrix.branch }}
+        uses: actions/checkout@v4
+        with:
+          repository: apache/httpd
+          ref: ${{ matrix.branch }}
+          path: httpd
+
+      - name: apt refresh
+        run: sudo apt-get -o Acquire::Retries=5 update
+      - name: Install prerequisites
+        run: sudo apt-get install -o Acquire::Retries=5
+                    cpanminus libtool-bin libapr1-dev libaprutil1-dev
+                    liblua5.3-dev libbrotli-dev libcurl4-openssl-dev
+                    libnghttp2-dev libjansson-dev libpcre2-dev
+                    perl-doc libsasl2-dev
+
+      - name: Install Perl dependencies
+        run: |
+          cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+          cpanm --notest Net::SSL LWP::Protocol::https \
+                         LWP::Protocol::AnyEvent::http ExtUtils::Embed Test::More \
+                         AnyEvent DateTime HTTP::DAV FCGI \
+                         AnyEvent::WebSocket::Client Apache::Test
+
+      - name: Build httpd
+        working-directory: httpd
+        run: |
+          ./buildconf --with-apr=/usr/bin/apr-1-config
+          ./configure --with-apr=/usr --enable-mods-shared=reallyall \
+                      --enable-mpms-shared=all --enable-load-all-modules \
+                      --prefix=$HOME/root/httpd
+          make -j$(nproc)
+          make install
+      - name: Run the test suite
+        run: |
+           eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+           perl Makefile.PL -apxs $HOME/root/httpd/bin/apxs
+           make test
+
+


### PR DESCRIPTION
  Builds Apache httpd from trunk and 2.4.x branches, then runs the
  test suite against the built installation.