### PR TITLE
Fix intermittent failure in t/modules/sed.t

### DIFF
--- a/t/modules/sed.t
+++ b/t/modules/sed.t
@@ -8,8 +8,13 @@ use Apache::TestUtil;
 my @ts = (
    # see t/conf/extra.conf.in
    { url => "/apache/sed/out-foo/foobar.html", content => 'barbar', msg => "sed output filter", code => '200' },
-   # error after status sent
-   { url => "/apache/sed-echo/out-foo-grow/foobar.html", content => "", msg => "sed output filter too large", code => '200', body=>"foo" x (8192*1024), resplen=>0},
+   # mod_sed gives up with ENOMEM once the substituted line grows past
+   # MAX_BUF_SIZE.  Whether a 200 was sent first depends on where the last
+   # read lands: if the handler's final write leaves data in the buffer, it
+   # is flushed with the EOS, mod_sed fails on that brigade and drops the
+   # EOS, and no response is sent at all.  Accept either outcome.
+   { url => "/apache/sed-echo/out-foo-grow/foobar.html", content => "", msg => "sed output filter too large",
+     code => qr/^(?:200|5\d\d)$/, body=>"foo" x (8192*1024), resplen=>0},
    { url => "/apache/sed-echo/input", content => 'barbar', msg => "sed input filter", code => '200', body=>"foobar" },
    { url => "/apache/sed-echo/input", content => undef, msg => "sed input filter", code => '200', body=>"foo" x (1024)},
    # fixme: returns 400 default error doc for some people instead


### PR DESCRIPTION
`t/modules/sed.t` test 3 fails intermittently. Seen on an httpd CI run
([job](https://github.com/apache/httpd/actions/runs/33258377716/job/99115948132)),
where the harness's own `-v` re-run of the same file then passed, as did the
same job on the next push.

The case POSTs 24 MiB through `mod_echo_post` with an `OutputSed` which grows
each line. `mod_sed` gives up with `APR_ENOMEM` once the substituted line
exceeds `MAX_BUF_SIZE`, logging `AH10394` 2048 times in both the passing and
the failing run. What differs is where the last socket read lands:

- Passing: every read is exactly 8192 bytes, so each `ap_rwrite()` exceeds the
  free space in the `ap_old_write` buffer and flushes inline. Nothing is left
  at EOS, sed's EOS branch succeeds, and a `200` goes out.
- Failing: one short read means the final write is small enough to sit in the
  buffer, so it is flushed together with the EOS. `sed_response_filter()` fails
  on that brigade and `break`s without calling `ap_pass_brigade()`, so the EOS
  is dropped and the header filters never run. No response bytes are written at
  all, and the client sees a clean EOF.

So the test asserts a status code for a case whose outcome depends on TCP read
boundaries. This accepts either, while still rejecting the `400` that the
neighbouring commented-out case mentions. There is precedent in this file:
c20d4f30 disabled a sibling entry for the same class of flakiness.

Not fixed here, and worth a look separately: `sed_response_filter()` dropping
the EOS means a request can end with no response whatsoever, rather than a
truncated 200 or a 500. That is httpd's `modules/filters/mod_sed.c`.

Note: I could not run this test locally to confirm, as
`LWP::Protocol::AnyEvent::http` is not available here and the whole file skips
without it. The change is syntax-checked, and `t_is_equal()` does support a
`Regexp` as the expected value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
